### PR TITLE
Support JSON Arrays and some non-string JTokens

### DIFF
--- a/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
+++ b/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
@@ -133,20 +133,47 @@ namespace VaultSharp.Extensions.Configuration
                                 break;
                             case JTokenType.None:
                             case JTokenType.Array:
+                                var array = (JArray)token;
+                                for (var i = 0; i < array.Count; i++)
+                                {
+                                    if (array[i].Type == JTokenType.Array)
+                                    {
+                                        this.SetData<JToken?>(array[i].Value<JObject>(), $"{nestedKey}:{i}");
+                                    }
+                                    else
+                                    {
+                                        this.Set($"{nestedKey}:{i}", array[i].Value<string>());
+                                    }
+                                }
+
+                                break;
                             case JTokenType.Constructor:
                             case JTokenType.Property:
                             case JTokenType.Comment:
                             case JTokenType.Integer:
+                                this.Set(nestedKey, token.Value<string>());
+                                break;
                             case JTokenType.Float:
+                                this.Set(nestedKey, token.Value<string>());
+                                break;
                             case JTokenType.Boolean:
+                                this.Set(nestedKey, token.Value<string>());
+                                break;
                             case JTokenType.Null:
                             case JTokenType.Undefined:
                             case JTokenType.Date:
+                                this.Set(nestedKey, token.Value<string>());
+                                break;
                             case JTokenType.Raw:
                             case JTokenType.Bytes:
                             case JTokenType.Guid:
+                                this.Set(nestedKey, token.Value<string>());
+                                break;
                             case JTokenType.Uri:
+                                this.Set(nestedKey, token.Value<string>());
+                                break;
                             case JTokenType.TimeSpan:
+                                this.Set(nestedKey, token.Value<string>());
                                 break;
                         }
 


### PR DESCRIPTION
This adds support for JArray, and some of the other JToken types that are easy to convert to strings.  Output should be similar to the results of [JsonConfigurationExtensions.AddJsonFile](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.jsonconfigurationextensions.addjsonfile?view=dotnet-plat-ext-5.0).  I probably didn't cover some corner cases, but I'm expecting that this would be working against JSON that looks like what would normally be in appsettings.json...
