### PR TITLE
🐛 fix - keys with substring of base path not working

### DIFF
--- a/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
+++ b/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
@@ -95,8 +95,7 @@ namespace VaultSharp.Extensions.Configuration
                 this._logger?.LogDebug($"VaultConfigurationProvider: got Vault data with key `{secretData.Key}`");
 
                 var key = secretData.Key;
-                key = key.Replace(this._source.BasePath, string.Empty, StringComparison.InvariantCultureIgnoreCase).TrimStart('/')
-                    .Replace('/', ':');
+                key = key.TrimStart('/')[this._source.BasePath.TrimStart('/').Length..].Replace('/', ':');
                 key = this.ReplaceTheAdditionalCharactersForConfigurationPath(key);
                 var data = secretData.SecretData.Data;
 


### PR DESCRIPTION
If the base path was also a substring of some key, the key was not properly loaded.