### PR TITLE
Add possibility to pass IAuthMethodInfo implementation to VaultOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,29 @@ config.AddVaultConfiguration(
         "secret");
 ```
 new VaultOptions("http://localhost:8200", "root", null, null, false, 300, false, new []{'.'}),
-## Configuration using environmnt variables
+## Configuration using environment variables
 
-Alternatively, you can configure Vault connection using next environmnt variables:
+Alternatively, you can configure Vault connection using next environment variables:
 
 - `VAULT_ADDR` : Address of the Vault instance. Default value is `"http://locahost:8200`.
 - `VAULT_TOKEN` : Vault token. Used for token-based authentication. Default value is `root`.
 - `VAULT_ROLEID` : Vault AppRole ID. Used for AppRole-based authentication.
 - `VAULT_SECRET` : Vault AppRole secret. Used for AppRole-based authentication.
+
+## Configuration using IAuthMethodInfo
+
+You can configure Vault connection using any supported auth method (look at https://github.com/rajanadar/VaultSharp#auth-methods):
+
+```csharp
+config.AddVaultConfiguration(
+        () => new VaultOptions(
+            "htpp://localhost:8200",
+            new KerberosAuthMethodInfo(),
+            reloadOnChange: true,
+            reloadCheckIntervalSeconds: 60),
+        "sampleapp",
+        "secret");
+```
 
 ## Preparing secrets in Vault
 

--- a/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
+++ b/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
@@ -53,7 +53,11 @@ namespace VaultSharp.Extensions.Configuration
                 if (this._vaultClient == null)
                 {
                     IAuthMethodInfo authMethod;
-                    if (!string.IsNullOrEmpty(this._source.Options.VaultRoleId) &&
+                    if (this._source.Options.AuthMethod != null)
+                    {
+                        authMethod = this._source.Options.AuthMethod;
+                    }
+                    else if (!string.IsNullOrEmpty(this._source.Options.VaultRoleId) &&
                         !string.IsNullOrEmpty(this._source.Options.VaultSecret))
                     {
                         this._logger?.LogDebug("VaultConfigurationProvider: using AppRole authentication");

--- a/Source/VaultSharp.Extensions.Configuration/VaultOptions.cs
+++ b/Source/VaultSharp.Extensions.Configuration/VaultOptions.cs
@@ -2,6 +2,7 @@ namespace VaultSharp.Extensions.Configuration
 {
     using System;
     using System.Collections.Generic;
+    using VaultSharp.V1.AuthMethods;
 
     /// <summary>
     /// Vault options class.
@@ -41,6 +42,39 @@ namespace VaultSharp.Extensions.Configuration
             this.AdditionalCharactersForConfigurationPath = additionalCharactersForConfigurationPath ?? Array.Empty<char>();
             this.Namespace = @namespace;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VaultOptions"/> class.
+        /// </summary>
+        /// <param name="vaultAddress">Vault address.</param>
+        /// <param name="authMethod">Vault auth method.</param>
+        /// <param name="reloadOnChange">Reload secrets if changed in Vault.</param>
+        /// <param name="reloadCheckIntervalSeconds">Interval in seconds to check Vault for any changes.</param>
+        /// <param name="omitVaultKeyName">Omit Vault Key Name in Configuration Keys.</param>
+        /// <param name="additionalCharactersForConfigurationPath">Additional characters for the Configuration path.</param>
+        /// <param name="namespace">Vault namespace.</param>
+        public VaultOptions(
+            string vaultAddress,
+            IAuthMethodInfo authMethod,
+            bool reloadOnChange = false,
+            int reloadCheckIntervalSeconds = 300,
+            bool omitVaultKeyName = false,
+            IEnumerable<char>? additionalCharactersForConfigurationPath = null,
+            string? @namespace = null)
+        {
+            this.VaultAddress = vaultAddress;
+            this.AuthMethod = authMethod;
+            this.ReloadOnChange = reloadOnChange;
+            this.ReloadCheckIntervalSeconds = reloadCheckIntervalSeconds;
+            this.OmitVaultKeyName = omitVaultKeyName;
+            this.AdditionalCharactersForConfigurationPath = additionalCharactersForConfigurationPath ?? Array.Empty<char>();
+            this.Namespace = @namespace;
+        }
+
+        /// <summary>
+        /// Gets Vault Auth method
+        /// </summary>
+        public IAuthMethodInfo? AuthMethod { get; }
 
         /// <summary>
         /// Gets Vault URL address.


### PR DESCRIPTION
There are a lot of supported auth methods such as Kerberos or AWS Token. 
Look at https://github.com/rajanadar/VaultSharp#auth-methods

Just pass IAuthMethodInfo implementation to VaultOptions constructor.