### PR TITLE
Change the behavior to throw exception on load errors

### DIFF
--- a/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
+++ b/Source/VaultSharp.Extensions.Configuration/VaultConfigurationProvider.cs
@@ -112,6 +112,7 @@ namespace VaultSharp.Extensions.Configuration
             catch (Exception e) when (e is VaultApiException || e is System.Net.Http.HttpRequestException)
             {
                 this.logger?.Log(LogLevel.Error, e, "Cannot load configuration from Vault");
+                throw;
             }
         }
 

--- a/Tests/VaultSharp.Extensions.Configuration.Test/IntegrationTests_SSL.cs
+++ b/Tests/VaultSharp.Extensions.Configuration.Test/IntegrationTests_SSL.cs
@@ -82,10 +82,11 @@ public partial class IntegrationTests
                 "test",
                 "secret",
                 this._logger);
-            var configurationRoot = builder.Build();
+            Action act = () => builder.Build();
+
 
             // assert
-            configurationRoot.GetValue<string>("option1").Should().BeNull();
+            act.Should().Throw<System.Net.Http.HttpRequestException>("The SSL connection could not be established, see inner exception.");
         }
         finally
         {


### PR DESCRIPTION
Change the behavior to throw an exception on load errors if authentication token/creds are invalid or there are some issues connecting to Vault.

