### PR TITLE
Add try catch block to address issue #56

### DIFF
--- a/Source/VaultSharp.Extensions.Configuration/VaultChangeWatcher.cs
+++ b/Source/VaultSharp.Extensions.Configuration/VaultChangeWatcher.cs
@@ -80,7 +80,7 @@ namespace VaultSharp.Extensions.Configuration
                 }
                 catch (Exception ex)
                 {
-                    this._logger?.LogError(ex,$"An exception occurred in {nameof(VaultChangeWatcher)}");
+                    this._logger?.LogError(ex, $"An exception occurred in {nameof(VaultChangeWatcher)}");
                 }
             }
         }

--- a/Source/VaultSharp.Extensions.Configuration/VaultChangeWatcher.cs
+++ b/Source/VaultSharp.Extensions.Configuration/VaultChangeWatcher.cs
@@ -32,7 +32,7 @@ namespace VaultSharp.Extensions.Configuration
             }
 
             this._logger = logger;
-            
+
             this._configProviders = configurationRoot.Providers.OfType<VaultConfigurationProvider>().Where(p => p.ConfigurationSource.Options.ReloadOnChange).ToList() !;
         }
 
@@ -54,25 +54,33 @@ namespace VaultSharp.Extensions.Configuration
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                await Task.Delay(TimeSpan.FromSeconds(minTime), stoppingToken).ConfigureAwait(false);
-                if (stoppingToken.IsCancellationRequested)
+                try
                 {
-                    break;
-                }
+                    await Task.Delay(TimeSpan.FromSeconds(minTime), stoppingToken).ConfigureAwait(false);
+                    if (stoppingToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
 
-                for (var j = 0; j < this._configProviders.Count(); j++)
+                    for (var j = 0; j < this._configProviders.Count(); j++)
+                    {
+                        var timer = timers[j];
+                        timer -= minTime;
+                        if (timer <= 0)
+                        {
+                            this._configProviders.ElementAt(j).Load();
+                            timers[j] = this._configProviders.ElementAt(j).ConfigurationSource.Options
+                                .ReloadCheckIntervalSeconds;
+                        }
+                        else
+                        {
+                            timers[j] = timer;
+                        }
+                    }
+                }
+                catch (Exception ex)
                 {
-                    var timer = timers[j];
-                    timer -= minTime;
-                    if (timer <= 0)
-                    {
-                        this._configProviders.ElementAt(j).Load();
-                        timers[j] = this._configProviders.ElementAt(j).ConfigurationSource.Options.ReloadCheckIntervalSeconds;
-                    }
-                    else
-                    {
-                        timers[j] = timer;
-                    }
+                    this._logger?.LogError(ex,$"An exception occurred in {nameof(VaultChangeWatcher)}");
                 }
             }
         }


### PR DESCRIPTION
This PR contains modifications in the VaultChangeWatcher adding a try catch block in the critical area to prevent the background service from stopping the host in case an exception occurs e.g TaskCancelledException when trying to load configuration from vault. Addresses issue #56 